### PR TITLE
Add TinyTools BG Remover to Images & Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ This list helps you discover the best tools & resources without wasting hours se
 - [Midjourney](https://www.midjourney.com/) - AI-generated art & illustrations
 - [Runway](https://runwayml.com/) - Video editing & gen AI tools
 - [Stable Diffusion](https://stability.ai/) - Open-source image generation
+- [TinyTools BG Remover](https://tinytools-smoky.vercel.app/) - Browser-based AI background remover (ONNX/WASM, runs locally, no upload, no signup); part of free open-source TinyTools suite for indie makers
 
 ---
 


### PR DESCRIPTION
Hi! Adding **TinyTools BG Remover** to the Images & Video section.

**What it is:** [TinyTools](https://tinytools-smoky.vercel.app/) is a free, open-source suite of single-purpose browser utilities for indie makers. The AI background remover runs **entirely locally in the browser** (ONNX/WASM) — no upload to any server, no signup, no API keys, no rate limits.

**Why it fits this list:**
- AI-native (background removal model runs locally via ONNX Runtime Web)
- Indie-maker friendly: free, open source, no infrastructure cost to the user
- Pairs well with other tools in the list (Stable Diffusion, Midjourney, Runway) for indie image workflows

The broader TinyTools suite also includes an OG image generator, favicon generator, color palette generator, SEO meta tag generator, AI cost calculator, EU AI Act–compliant content disclosure generator, and an AI robots.txt generator — happy to submit follow-up entries for other sections if useful.

Entry is added in alphabetical order at the end of the Images & Video section as per CONTRIBUTING.md.

Thanks for considering!

